### PR TITLE
fix: encount for the new sveltekit vite config placement

### DIFF
--- a/packages/vitest-svelte-kit/src/index.ts
+++ b/packages/vitest-svelte-kit/src/index.ts
@@ -16,7 +16,7 @@ export async function extractFromSvelteConfig(inlineConfig?: SvelteConfig) {
         inlineConfig ?? (await import(file).then((module) => module.default))
 
     const { plugins: userPlugins = [], ...userConfig } = getValue(
-        svelteConfig.kit?.vite ?? {}
+        svelteConfig.vite ?? svelteConfig.kit?.vite ?? {}
     )
 
     return defineConfig({


### PR DESCRIPTION
The newest SvelteKit has 'vite' placed on a higher level, not within the 'kit' configuration. This PR fixes that, while allowing for older configurations to keep working as well. 

https://kit.svelte.dev/docs/configuration