### PR TITLE
Add @testing-library/jest-dom to the example

### DIFF
--- a/examples/svelte-kit-demo-app/README.md
+++ b/examples/svelte-kit-demo-app/README.md
@@ -2,8 +2,9 @@
 
 ## Additional Dependencies
 
-After this project was created with `npm create svelte@next svelte-kit-demo-app`, the following dependecies were installed:
+After this project was created with `npm create svelte@next svelte-kit-demo-app`, the following dependencies were installed:
 
+-   `@testing-library/jest-dom`
 -   `@testing-library/svelte`
 -   `jsdom`
 -   `vitest`

--- a/examples/svelte-kit-demo-app/package.json
+++ b/examples/svelte-kit-demo-app/package.json
@@ -13,6 +13,7 @@
     "devDependencies": {
         "@sveltejs/adapter-auto": "next",
         "@sveltejs/kit": "next",
+        "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/svelte": "^3.0.3",
         "@types/cookie": "^0.4.1",
         "jsdom": "^19.0.0",
@@ -21,7 +22,7 @@
         "svelte-preprocess": "^4.10.2",
         "tslib": "^2.3.1",
         "typescript": "^4.5.5",
-        "vitest": "^0.1.27",
+        "vitest": "^0.13.1",
         "vitest-svelte-kit": "workspace:*"
     },
     "type": "module",

--- a/examples/svelte-kit-demo-app/setupTests.ts
+++ b/examples/svelte-kit-demo-app/setupTests.ts
@@ -1,0 +1,8 @@
+import { cleanup } from '@testing-library/svelte';
+import { afterEach } from 'vitest';
+
+import '@testing-library/jest-dom/extend-expect';
+
+afterEach(() => {
+	cleanup();
+});

--- a/examples/svelte-kit-demo-app/src/routes/about.test.ts
+++ b/examples/svelte-kit-demo-app/src/routes/about.test.ts
@@ -1,15 +1,13 @@
-import { beforeEach, test, expect } from "vitest"
-import { cleanup, render } from "@testing-library/svelte"
+import { test, expect } from "vitest"
+import { render, screen } from "@testing-library/svelte"
 
 import About from "./about.svelte"
-
-beforeEach(cleanup)
 
 test("can render", () => {
     render(About)
 })
 
 test("can find the correct page title", () => {
-    const { getByText } = render(About)
-    expect(getByText("About this app")).toBeDefined()
+    render(About)
+    expect(screen.getByText("About this app")).toBeInTheDocument();
 })

--- a/examples/svelte-kit-demo-app/svelte.config.js
+++ b/examples/svelte-kit-demo-app/svelte.config.js
@@ -16,6 +16,16 @@ const config = {
         vite: {
             test: {
                 environment: "jsdom",
+                /*
+                    `@testing-library/jest-dom` relies on Jest globals
+                    (`expect`, for instance). But we don't need the globals to
+                    be presented in our tests - we need to get them via imports
+                    from `vitest`. That's why the appropriate types
+                    (`vitest/globals`) are not added to `tsconfig.json`, as
+                    advised in the [docs](https://vitest.dev/config/#globals).
+                */
+                globals: true,
+                setupFiles: ['setupTests.ts']
             },
         },
     },

--- a/examples/svelte-kit-demo-app/tsconfig.json
+++ b/examples/svelte-kit-demo-app/tsconfig.json
@@ -5,16 +5,16 @@
         "lib": ["es2020", "DOM"],
         "target": "es2020",
         /**
-			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
-			to enforce using \`import type\` instead of \`import\` for Types.
-			*/
+            svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
+            to enforce using \`import type\` instead of \`import\` for Types.
+        */
         "importsNotUsedAsValues": "error",
         "isolatedModules": true,
         "resolveJsonModule": true,
         /**
-			To have warnings/errors of the Svelte compiler at the correct position,
-			enable source maps by default.
-			*/
+            To have warnings/errors of the Svelte compiler at the correct position,
+            enable source maps by default.
+        */
         "sourceMap": true,
         "esModuleInterop": true,
         "skipLibCheck": true,


### PR DESCRIPTION
What has been done:
* Installed [@testing-library/jest-dom](https://www.npmjs.com/package/@testing-library/jest-dom) package
* Updated Vitest version (the older version doesn't catch the updated matchers types)
* Moved cleanup and the matchers extending to a separate file (`setupTests.ts`). Also changed `beforeEach` to `afterEach` for the cleanup (to match the [example in the @testing-library/svelte docs](https://testing-library.com/docs/svelte-testing-library/api#cleanup))
* Overrode `globals` and `setupFiles` fields in the tests' setup (in `svelte.config.js` file)
* Used `toBeInTheDocument` matcher instead of `toBeDefined` to check the changed and TypeScript support
* Used `getByText` from the imported `screen` object instead of the one from the `render` result ([here is why](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen))
* Fixed comments indentation in `tsconfig.json`
* Added a note about `@testing-library/jest-dom` to `README.md` and fixed a typo out there